### PR TITLE
Add death info of Cinder Spark striking for 1.12.x version

### DIFF
--- a/src/main/resources/assets/champions/lang/en_us.lang
+++ b/src/main/resources/assets/champions/lang/en_us.lang
@@ -29,6 +29,7 @@ champions.injured=Injured
 champions.immune=Immune
 
 death.attack.reflecting=%1$s got a taste of their own medicine
+death.attack.cinderSpark=%1$s was striken by Cinder Spark
 
 #################
 #     Items     #

--- a/src/main/resources/assets/champions/lang/zh_cn.lang
+++ b/src/main/resources/assets/champions/lang/zh_cn.lang
@@ -29,6 +29,7 @@ champions.injured=易伤
 champions.immune=免伤
 
 death.attack.reflecting=%1$s遭报应了
+death.attack.cinderSpark=%1$s被火球击中
 
 #################
 #     Items     #


### PR DESCRIPTION
Hello TheIllusiveC4!
I have played your Champions Mod, It's pretty challenging and interesting. I love it indeed.
But I found that, in the latest 1.12.x version, when fireballs shot by some Champions elite mobs with Cinder affix kill a player,
the death info is not present, and only "death.info.cinderSpark" is shown.
So I added its corresponding death info into your language files, and tested it in game. It should work properly.

Would you like to have this modification merged into your mod?
Thanks in advance!