### PR TITLE
Champion killed by player advancement trigger

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ bin
 .classpath
 .project
 
+# vscode
+.vscode
+
 # idea
 out
 *.ipr

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     repositories {
         maven { url = 'https://files.minecraftforge.net/maven' }
         maven { url = 'https://plugins.gradle.org/m2/' }
-		maven { url = 'https://maven.parchmentmc.org' }
+        maven { url = 'https://maven.parchmentmc.org' }
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -10,13 +10,14 @@ buildscript {
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
         classpath group: 'gradle.plugin.com.matthewprenger', name: 'CurseGradle', version: '1.4.0'
-		classpath group: 'org.parchmentmc', name: 'librarian', version: '1.+'
+        classpath group: 'org.parchmentmc', name: 'librarian', version: '1.+'
     }
 }
 
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'com.matthewprenger.cursegradle'
 apply plugin: 'org.parchmentmc.librarian.forgegradle'
+apply plugin: 'eclipse'
 
 version = "${mod_version}"
 group = "top.theillusivec4.champions"
@@ -67,6 +68,7 @@ repositories {
 dependencies {
     minecraft "net.minecraftforge:forge:${forge_version}"
 
+    compileOnly fg.deobf("curse.maven:silent-lib-242998:${cf_silentlib}")
     compileOnly fg.deobf("curse.maven:scalinghealth-248027:${cf_scalinghealth}")
 }
 

--- a/src/main/java/top/theillusivec4/champions/Champions.java
+++ b/src/main/java/top/theillusivec4/champions/Champions.java
@@ -19,13 +19,16 @@
 
 package top.theillusivec4.champions;
 
-import com.electronwill.nightconfig.core.CommentedConfig;
-import com.google.gson.JsonObject;
 import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.google.gson.JsonObject;
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import net.minecraft.client.Minecraft;
 import net.minecraft.commands.synchronization.ArgumentSerializer;
 import net.minecraft.commands.synchronization.ArgumentTypes;
@@ -54,9 +57,6 @@ import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLPaths;
-import org.apache.commons.io.FileUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import top.theillusivec4.champions.api.IChampion;
 import top.theillusivec4.champions.api.IChampionsApi;
 import top.theillusivec4.champions.api.impl.ChampionsApiImpl;
@@ -73,6 +73,7 @@ import top.theillusivec4.champions.common.rank.RankManager;
 import top.theillusivec4.champions.common.registry.ChampionsRegistry;
 import top.theillusivec4.champions.common.registry.RegistryReference;
 import top.theillusivec4.champions.common.util.EntityManager;
+import top.theillusivec4.champions.server.advancement.ChampionsCriterionTriggers;
 import top.theillusivec4.champions.server.command.AffixArgument;
 import top.theillusivec4.champions.server.command.ChampionsCommand;
 
@@ -98,6 +99,7 @@ public class Champions {
     eventBus.addListener(this::registerCaps);
     MinecraftForge.EVENT_BUS.addListener(this::registerCommands);
     scalingHealthLoaded = ModList.get().isLoaded("scalinghealth");
+    ChampionsCriterionTriggers.init();
   }
 
   private void setup(final FMLCommonSetupEvent evt) {

--- a/src/main/java/top/theillusivec4/champions/common/ChampionEventsHandler.java
+++ b/src/main/java/top/theillusivec4/champions/common/ChampionEventsHandler.java
@@ -8,6 +8,7 @@ import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffect;
@@ -47,6 +48,7 @@ import top.theillusivec4.champions.common.rank.Rank;
 import top.theillusivec4.champions.common.registry.ChampionsRegistry;
 import top.theillusivec4.champions.common.registry.RegistryReference;
 import top.theillusivec4.champions.common.util.ChampionBuilder;
+import top.theillusivec4.champions.server.advancement.ChampionsCriterionTriggers;
 
 @SuppressWarnings("unused")
 public class ChampionEventsHandler {
@@ -279,7 +281,9 @@ public class ChampionEventsHandler {
         }
       });
       serverChampion.getRank().ifPresent(rank -> {
-        if (!evt.isCanceled() && evt.getSource().getDirectEntity() instanceof Player) {
+        if (!evt.isCanceled() && evt.getSource().getEntity() instanceof ServerPlayer player) {
+          ChampionsCriterionTriggers.CHAMPION_KILLED_BY_PLAYER.trigger(player, livingEntity, rank.getTier(), serverChampion.getAffixes());
+
           int messageTier = ChampionsConfig.deathMessageTier;
 
           if (messageTier > 0 && rank.getTier() >= messageTier) {

--- a/src/main/java/top/theillusivec4/champions/server/advancement/ChampionsCriterionTriggers.java
+++ b/src/main/java/top/theillusivec4/champions/server/advancement/ChampionsCriterionTriggers.java
@@ -1,0 +1,12 @@
+package top.theillusivec4.champions.server.advancement;
+
+import net.minecraft.advancements.CriteriaTriggers;
+import top.theillusivec4.champions.server.advancement.criterion.ChampionKilledByPlayerTrigger;
+
+public class ChampionsCriterionTriggers {
+
+  public static final ChampionKilledByPlayerTrigger CHAMPION_KILLED_BY_PLAYER = CriteriaTriggers.register(new ChampionKilledByPlayerTrigger());
+
+  public static void init() {}
+
+}

--- a/src/main/java/top/theillusivec4/champions/server/advancement/criterion/ChampionKilledByPlayerTrigger.java
+++ b/src/main/java/top/theillusivec4/champions/server/advancement/criterion/ChampionKilledByPlayerTrigger.java
@@ -1,0 +1,82 @@
+package top.theillusivec4.champions.server.advancement.criterion;
+
+import java.util.HashSet;
+import java.util.List;
+import com.google.gson.JsonObject;
+import org.codehaus.plexus.util.CollectionUtils;
+import net.minecraft.advancements.critereon.AbstractCriterionTriggerInstance;
+import net.minecraft.advancements.critereon.DeserializationContext;
+import net.minecraft.advancements.critereon.EntityPredicate;
+import net.minecraft.advancements.critereon.MinMaxBounds;
+import net.minecraft.advancements.critereon.SimpleCriterionTrigger;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.LivingEntity;
+import top.theillusivec4.champions.Champions;
+import top.theillusivec4.champions.api.IAffix;
+
+public class ChampionKilledByPlayerTrigger extends SimpleCriterionTrigger<ChampionKilledByPlayerTrigger.Instance> {
+
+  private static final ResourceLocation ID = new ResourceLocation(Champions.MODID, "champion_killed_by_player");
+
+  @Override
+  public ResourceLocation getId() {
+    return ID;
+  }
+
+  @Override
+  protected Instance createInstance(JsonObject json, EntityPredicate.Composite player, DeserializationContext parser) {
+    var entity = EntityPredicate.fromJson(json.get("entity"));
+    var tier = MinMaxBounds.Ints.fromJson(json.get("tier"));
+    var affix = new HashSet<String>() {
+      {
+        if (json.has("affixes")) {
+          GsonHelper.getAsJsonArray(json, "affixes").forEach((affixJson) -> add(GsonHelper.convertToString(affixJson, "affix")));
+        }
+      }
+    };
+    boolean matchAllAffixes = GsonHelper.getAsBoolean(json, "match_all_affixes", true);
+    return new Instance(player, entity, tier, affix, matchAllAffixes);
+  }
+
+  public void trigger(ServerPlayer player, LivingEntity championEntity, int tier, List<IAffix> affixes) {
+    this.trigger(player, (instance) -> instance.test(player, championEntity, tier, affixes));
+  }
+
+  public static class Instance extends AbstractCriterionTriggerInstance {
+
+    private final EntityPredicate entity;
+    private final MinMaxBounds.Ints tier;
+    private final HashSet<String> affixes;
+    private final boolean matchAllAffixes;
+
+    public Instance(EntityPredicate.Composite player, EntityPredicate entity, MinMaxBounds.Ints tier, HashSet<String> affixes, boolean matchAllAffixes) {
+      super(ID, player);
+      this.entity = entity;
+      this.tier = tier;
+      this.affixes = affixes;
+      this.matchAllAffixes = matchAllAffixes;
+    }
+
+    public boolean test(ServerPlayer player, LivingEntity championEntity, int tier, List<IAffix> affixes) {
+      boolean e = this.entity.matches((ServerLevel) championEntity.getLevel(), championEntity.position(), championEntity);
+      boolean t =  this.tier.matches(tier);
+      boolean a = matchAffixes(this.affixes, affixes.stream().map(IAffix::getIdentifier).toList(), this.matchAllAffixes);
+      return e && t && a;
+    }
+
+    private static boolean matchAffixes(HashSet<String> a, List<String> b, boolean matchAll) {
+      if (a.isEmpty()) return true;
+      if (matchAll) {
+        if (a.size() != b.size()) return false;
+        return a.equals(new HashSet<>(b));
+      } else {
+        return !CollectionUtils.intersection(a, b).isEmpty();
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
I programmed an achievement trigger that triggers when a champion mob is killed by a player.
This will be useful for modpack authors.

Usage example:
```json
{
    "display": {
        "title": "TEST",
        "description": "Test"
    },
    "criteria": {
        "test": {
            "trigger": "champions:champion_killed_by_player",
            "conditions": {
                "entity": { "type": "minecraft:husk" },
                "tier": { "min": 2 },
                "affixes": ["lively", "enkindling"],
                "match_all_affixes": false
            }
        }
    }
}

```